### PR TITLE
Direct use of PAPI counter names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,9 @@ To use this plugin, add it to the `SCOREP_METRIC_PLUGINS` environment variable, 
     export SCOREP_METRIC_PLUGINS="apapi_plugin"
 
 All avaible papi counter should be avaible in this plugin. To use them, simply set the
-`SCOREP_METRIC_APAPI_PLUGIN` environment variable. Prefix the PAPI counter name with A, e.g.
+desired PAPI counters in the `SCOREP_METRIC_APAPI_PLUGIN` environment variable.
 
-    export SCOREP_METRIC_APAPI_PLUGIN="L2_TCM,FP_INS"
-
-In order to record papi native counters, you have to use the `NPAPI::` prefix, e.g.
-
-    export SCOREP_METRIC_APAPI_PLUGIN="NPAPI::perf::CYCLES"
+    export SCOREP_METRIC_APAPI_PLUGIN="PAPI_L2_TCM,PAPI_FP_INS"
 
 ### VampirTrace
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ All avaible papi counter should be avaible in this plugin. To use them, simply s
 
     export SCOREP_METRIC_APAPI_PLUGIN="L2_TCM,FP_INS"
 
+In order to record papi native counters, you have to use the `NPAPI::` prefix, e.g.
+
+    export SCOREP_METRIC_APAPI_PLUGIN="NPAPI::perf::CYCLES"
+
 ### VampirTrace
 
 All avaible papi counter should be avaible in this plugin. To use them, simply set the

--- a/apapi.c
+++ b/apapi.c
@@ -222,7 +222,7 @@ metric_properties_t * get_event_info(char * event_name)
     /* Prepend APAPI_ to create a meaningful counter name */
     int ret;
 
-    #define STR_SIZE 64
+    #define STR_SIZE 128
 
     char apapi_name[STR_SIZE];
     memset(apapi_name, 0, STR_SIZE);

--- a/apapi.c
+++ b/apapi.c
@@ -222,29 +222,36 @@ metric_properties_t * get_event_info(char * event_name)
     /* convert prepend PAPI_ to event name to get the event code
      * and prepend APAPI_ to create a meaningful counter name */
     int ret;
-    
+
     #define STR_SIZE 64
-    
+    const char *papi_native_prefix = "NPAPI::";
+    const size_t native_prefix_len = strlen(papi_native_prefix);
+
     char papi_name[STR_SIZE];
     char apapi_name[STR_SIZE];
     memset(papi_name, 0, STR_SIZE);
     memset(apapi_name, 0, STR_SIZE);
-    
+
     if (strncmp("PAPI_", event_name, 5) == 0)
     {
-        /* these two calls obviously are safe */  
+        /* these two calls obviously are safe */
         strcpy(apapi_name, "A");
+    }
+    else if (strncmp(papi_native_prefix, event_name, native_prefix_len) == 0)
+    {
+        event_name = &event_name[native_prefix_len];
+        strcpy(apapi_name, papi_native_prefix);
     }
     else
     {
-        /* these two calls obviously are safe */  
+        /* these two calls obviously are safe */
         strcpy(papi_name, "PAPI_");
         strcpy(apapi_name, "APAPI_");
     }
-    
+
     /* ... while these are not */
     strncat(papi_name, event_name, strlen(papi_name)-STR_SIZE-1);
-    strncat(apapi_name, event_name, strlen(apapi_name)-STR_SIZE-1);
+    strncat(apapi_name, event_name, strlen(apapi_name) - STR_SIZE - 1);
 
     /* parse the event name and put the event code into a global variable */
     if ((ret = PAPI_event_name_to_code(papi_name, &EventCodes[global_num_cntrs])) != PAPI_OK) {
@@ -252,7 +259,7 @@ metric_properties_t * get_event_info(char * event_name)
         return NULL;
     }
 
-    /* check if the counter is avaible on this architecture */
+    /* check if the counter is available on this architecture */
     if ((ret = PAPI_query_event(EventCodes[global_num_cntrs])) != PAPI_OK) {
         fprintf(stderr, "APAPI: event %s is not avaible on this architecture\n", event_name);
         return NULL;
@@ -260,8 +267,7 @@ metric_properties_t * get_event_info(char * event_name)
 
     global_num_cntrs++;
 
-    metric_properties_t *return_values = malloc(2 *
-        sizeof(metric_properties_t));
+    metric_properties_t *return_values = malloc(2 * sizeof(metric_properties_t));
 
     if (return_values == NULL)
     {

--- a/apapi.c
+++ b/apapi.c
@@ -219,43 +219,20 @@ int32_t init(void)
 
 metric_properties_t * get_event_info(char * event_name)
 {
-    /* convert prepend PAPI_ to event name to get the event code
-     * and prepend APAPI_ to create a meaningful counter name */
+    /* Prepend APAPI_ to create a meaningful counter name */
     int ret;
 
     #define STR_SIZE 64
-    const char *papi_native_prefix = "NPAPI::";
-    const size_t native_prefix_len = strlen(papi_native_prefix);
 
-    char papi_name[STR_SIZE];
     char apapi_name[STR_SIZE];
-    memset(papi_name, 0, STR_SIZE);
     memset(apapi_name, 0, STR_SIZE);
-
-    if (strncmp("PAPI_", event_name, 5) == 0)
-    {
-        /* these two calls obviously are safe */
-        strcpy(apapi_name, "A");
-    }
-    else if (strncmp(papi_native_prefix, event_name, native_prefix_len) == 0)
-    {
-        event_name = &event_name[native_prefix_len];
-        strcpy(apapi_name, papi_native_prefix);
-    }
-    else
-    {
-        /* these two calls obviously are safe */
-        strcpy(papi_name, "PAPI_");
-        strcpy(apapi_name, "APAPI_");
-    }
-
-    /* ... while these are not */
-    strncat(papi_name, event_name, strlen(papi_name)-STR_SIZE-1);
+    strcpy(apapi_name, "A");
     strncat(apapi_name, event_name, strlen(apapi_name) - STR_SIZE - 1);
 
     /* parse the event name and put the event code into a global variable */
-    if ((ret = PAPI_event_name_to_code(papi_name, &EventCodes[global_num_cntrs])) != PAPI_OK) {
-        fprintf(stderr, "APAPI: Failed to encode event %s: %s\n", papi_name, PAPI_strerror(ret));
+    if ((ret = PAPI_event_name_to_code(event_name, &EventCodes[global_num_cntrs])) != PAPI_OK)
+    {
+        fprintf(stderr, "APAPI: Failed to encode event %s: %s\n", event_name, PAPI_strerror(ret));
         return NULL;
     }
 


### PR DESCRIPTION
This is important if someone uses PAPI components.
In the current implementation, it does not work with PAPI component names because of the prepending of the "PAPI" string.